### PR TITLE
Future proof

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -9,7 +9,6 @@
 
 var _ = require('underscore');
 var fs = require('fs');
-var path = require('path');
 var Module = require('module');
 
 var originalWrapper = Module.wrapper.slice(0);

--- a/lib/requizzle.js
+++ b/lib/requizzle.js
@@ -12,7 +12,6 @@
 var _ = require('underscore');
 var loader = require('./loader');
 var Module = require('module');
-var path = require('path');
 
 /**
  * Function that returns text to swizzle into the module.

--- a/lib/requizzle.js
+++ b/lib/requizzle.js
@@ -40,13 +40,12 @@ var path = require('path');
  */
 
 function isNativeModule(targetPath, parentModule) {
-	var lookupPaths = Module._resolveLookupPaths(targetPath, parentModule);
-
-	if (lookupPaths[0] === targetPath && lookupPaths[1].length === 0) {
-		return true;
-	}
-
-	return false;
+	var lookupPaths = Module._resolveLookupPaths(targetPath, parentModule, true);
+	/* istanbul ignore next */
+	return lookupPaths === null ||
+		lookupPaths.length === 2 &&
+		lookupPaths[1].length === 0 &&
+		lookupPaths[0] === targetPath;
 }
 
 /**


### PR DESCRIPTION
This updates the call to _resolveLookupPaths. It returns a string
by default since Node.js v8 when called with a third truthy argument.
The backwards compatible return value should change soon, so detect
what return type is used and handle both cases.

Refs: nodejs/node#26983

-----

This module uses a lot of Node.js internal functions. Something that recently changed is the wrapper and it is now auto detected if a module manipulates the wrapper or not. If that's the case, a compatibility mode is used instead of the regular file loading mechanism currently in place. It would be great if a different solution could be found than manipulating the wrapper (or the wrapper function).